### PR TITLE
Add Semantic Scholar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ data/
 !data/.keep
 *.json
 *.bib
+
+!**/*/fixtures/*.json

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ in different sources and export the results.
 ## Available sources
 
 - [x] [OpenAlex](https://openalex.org/)
+- [x] [Semantic Scholar](https://api.semanticscholar.org/)
 
 ...and [many more to come](https://github.com/anapaulagomes/peneira/issues?q=is%3Aissue+is%3Aopen+label%3Asources)!
 Feel free to contribute. There is [a world of papers](https://en.wikipedia.org/wiki/List_of_academic_databases_and_search_engines)
@@ -37,23 +38,15 @@ You can interact with the CLI using `peneira`. For example, to search for papers
 _"artificial intelligence" and "syndromic surveillance"_ and save the results to a file, you can run:
 
 ```bash
-peneira '"artificial intelligence" and "syndromic surveillance"' --filename my-papers.json
+peneira -s open_alex -s semantic_scholar --filename my-papers.json
 ```
 
-It will search for papers in OpenAlex and store it in a file named `my-papers.json`.
+You will be prompted to enter the search query for each source. The lib will search for papers in
+OpenAlex and Semantic Scholar and store it in a file named `my-papers.json`.
+If no filename is provided, the results will be stored to `results.json`.
+
 You have also the option of export it to a bibtex file:
 
 ```bash
-peneira '"artificial intelligence" and "public health"' --format bibtex --filename my-papers.bib
-```
-
-### Python module
-
-In case you want to call the OpenAlex source directly, you can use the following code:
-
-```python
-import asyncio
-from peneira.sources.open_alex import fetch_papers
-
-asyncio.run(fetch_papers("artificial intelligence AND public health"))
+peneira -s open_alex -s semantic_scholar --format bibtex --filename my-papers.bib
 ```

--- a/peneira/__init__.py
+++ b/peneira/__init__.py
@@ -1,0 +1,11 @@
+import logging
+
+
+def setup_logger(name):
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.INFO)
+    stream_handler.setFormatter(logging.Formatter("%(module)s: %(message)s"))
+    logger.addHandler(stream_handler)
+    return logger

--- a/peneira/cli.py
+++ b/peneira/cli.py
@@ -3,29 +3,12 @@ import asyncio
 import asyncclick as click
 
 from peneira.exporters import write_results_to_file, to_json, to_bibtex
-from peneira.sources.open_alex import establish_number_of_pages, fetch_papers
-from peneira.sources.semantic_scholar import SemanticScholar
+from peneira.sources.open_alex import search_open_alex
+from peneira.sources.semantic_scholar import search_semantic_scholar
 
-
-async def create_open_alex_tasks(query):
-    number_of_pages, total = await establish_number_of_pages(query)
-    click.echo(
-        f"Fetching articles for OPEN_ALEX... {total} papers "
-        f"distributed in {number_of_pages} pages."
-    )
-    tasks = [fetch_papers(query, page) for page in range(1, number_of_pages + 1)]
-    return tasks
-
-
-async def create_semantic_scholar_tasks(query):
-    click.echo("Fetching articles for SEMANTIC_SCHOLAR...")
-    semantic_scholar = SemanticScholar(query=query)
-    return [semantic_scholar.search()]
-
-
-sources_func = {
-    "open_alex": create_open_alex_tasks,
-    "semantic_scholar": create_semantic_scholar_tasks,
+sources_search_func = {
+    "open_alex": search_open_alex,
+    "semantic_scholar": search_semantic_scholar,
 }
 
 
@@ -65,7 +48,7 @@ async def cli(filename, sources, output):
     for source in sources:
         search_string = click.prompt(f"Please enter the search string for {source}")
         try:
-            all_tasks.extend(await sources_func[source](search_string))
+            all_tasks.extend(await sources_search_func[source](search_string))
         except ValueError:
             raise ValueError(f"Unsupported source {source}")
 

--- a/peneira/sources/__init__.py
+++ b/peneira/sources/__init__.py
@@ -8,5 +8,6 @@ class ResultBundle:
 
     url: str
     source: str
+    _token: str = None
     results: list[dict] = field(default_factory=list, repr=False)
     created_at: datetime = field(default_factory=datetime.now)

--- a/peneira/sources/__init__.py
+++ b/peneira/sources/__init__.py
@@ -8,6 +8,5 @@ class ResultBundle:
 
     url: str
     source: str
-    _token: str = None
     results: list[dict] = field(default_factory=list, repr=False)
     created_at: datetime = field(default_factory=datetime.now)

--- a/peneira/sources/open_alex.py
+++ b/peneira/sources/open_alex.py
@@ -2,10 +2,12 @@ import math
 
 import httpx
 
+from peneira import setup_logger
 from peneira.sources import ResultBundle
 from aiolimiter import AsyncLimiter
 
 
+logger = setup_logger(__name__)
 BASE_URL = "https://api.openalex.org"
 WORKS_PER_PAGE = 200
 SOURCE = "open_alex"
@@ -87,3 +89,13 @@ def map_to_bibtex_type(capsule):
         "source": capsule.get("source", ""),
         "created_at": capsule.get("created_at", ""),
     }
+
+
+async def search_open_alex(query):
+    number_of_pages, total = await establish_number_of_pages(query)
+    logger.info(
+        f"Fetching articles for OPEN_ALEX... {total} papers "
+        f"distributed in {number_of_pages} pages."
+    )
+    tasks = [fetch_papers(query, page) for page in range(1, number_of_pages + 1)]
+    return tasks

--- a/peneira/sources/semantic_scholar.py
+++ b/peneira/sources/semantic_scholar.py
@@ -22,7 +22,7 @@ async def search_semantic_scholar(query, token=None):
             f"{BASE_URL}paper/search/bulk?query={query}&", params=params
         )
         results = response.json().get("data", [])
-        return ResultBundle(url=str(response.url), source=SOURCE, results=results)
-
-
-# TODO get token semantic scholar
+        token = response.json().get("token")
+        return ResultBundle(
+            url=str(response.url), source=SOURCE, results=results, _token=token
+        )

--- a/peneira/sources/semantic_scholar.py
+++ b/peneira/sources/semantic_scholar.py
@@ -3,8 +3,11 @@ from dataclasses import dataclass
 import httpx
 from aiolimiter import AsyncLimiter
 
+from peneira import setup_logger
 from peneira.sources import ResultBundle
 
+
+logger = setup_logger(__name__)
 
 BASE_URL = "https://api.semanticscholar.org/graph/v1/"
 SOURCE = "semantic_scholar"
@@ -51,3 +54,9 @@ class SemanticScholar:
                     return await self.search(_result_bundle=_result_bundle)
 
                 return _result_bundle
+
+
+async def search_semantic_scholar(query):
+    logger.info("Fetching articles for SEMANTIC_SCHOLAR...")
+    semantic_scholar = SemanticScholar(query=query)
+    return [semantic_scholar.search()]

--- a/peneira/sources/semantic_scholar.py
+++ b/peneira/sources/semantic_scholar.py
@@ -17,6 +17,7 @@ rate_limiter = AsyncLimiter(60)  # 60 request per minute
 
 
 async def search_semantic_scholar(query, token=None):
+    # Each call will return a new token that must be used to continue.
     params = {
         "fields": SEMANTIC_SCHOLAR_FIELDS,
         "token": token,

--- a/peneira/sources/semantic_scholar.py
+++ b/peneira/sources/semantic_scholar.py
@@ -1,0 +1,28 @@
+import httpx
+
+from peneira.sources import ResultBundle
+
+
+BASE_URL = "https://api.semanticscholar.org/graph/v1/"
+SOURCE = "semantic_scholar"
+SEMANTIC_SCHOLAR_FIELDS = (
+    "url,title,venue,year,authors,externalIds,abstract,openAccessPdf,"
+    "fieldsOfStudy,publicationTypes,journal"
+)
+# TODO rate limit
+
+
+async def search_semantic_scholar(query, token=None):
+    params = {
+        "fields": SEMANTIC_SCHOLAR_FIELDS,
+        "token": token,
+    }
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{BASE_URL}paper/search/bulk?query={query}&", params=params
+        )
+        results = response.json().get("data", [])
+        return ResultBundle(url=str(response.url), source=SOURCE, results=results)
+
+
+# TODO get token semantic scholar

--- a/peneira/sources/semantic_scholar.py
+++ b/peneira/sources/semantic_scholar.py
@@ -1,4 +1,5 @@
 import httpx
+from aiolimiter import AsyncLimiter
 
 from peneira.sources import ResultBundle
 
@@ -9,7 +10,10 @@ SEMANTIC_SCHOLAR_FIELDS = (
     "url,title,venue,year,authors,externalIds,abstract,openAccessPdf,"
     "fieldsOfStudy,publicationTypes,journal"
 )
-# TODO rate limit
+
+# with each unauthenticated IP limited to 1 request per second
+# https://www.semanticscholar.org/product/api
+rate_limiter = AsyncLimiter(60)  # 60 request per minute
 
 
 async def search_semantic_scholar(query, token=None):
@@ -17,12 +21,13 @@ async def search_semantic_scholar(query, token=None):
         "fields": SEMANTIC_SCHOLAR_FIELDS,
         "token": token,
     }
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            f"{BASE_URL}paper/search/bulk?query={query}&", params=params
-        )
-        results = response.json().get("data", [])
-        token = response.json().get("token")
-        return ResultBundle(
-            url=str(response.url), source=SOURCE, results=results, _token=token
-        )
+    async with rate_limiter:  # wait for a slot to be available
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{BASE_URL}paper/search/bulk?query={query}&", params=params
+            )
+            results = response.json().get("data", [])
+            token = response.json().get("token")
+            return ResultBundle(
+                url=str(response.url), source=SOURCE, results=results, _token=token
+            )

--- a/peneira/sources/semantic_scholar.py
+++ b/peneira/sources/semantic_scholar.py
@@ -30,7 +30,6 @@ class SemanticScholar:
         self._fields = SEMANTIC_SCHOLAR_FIELDS
 
     async def search(self, _result_bundle=None):
-        # Each call will return a new token that must be used to continue.
         params = {"fields": self._fields}
         if self._token:
             params["token"] = self._token

--- a/tests/sources/fixtures/semantic_paper_search_bulk.json
+++ b/tests/sources/fixtures/semantic_paper_search_bulk.json
@@ -1,0 +1,76 @@
+{
+  "total": 15117,
+  "token": "SDKJFHSDKFHWIEFSFSGHEIURYC",
+  "data": [
+    {
+      "paperId": "649def34f8be52c8b66281af98ae884c09aef38b",
+      "corpusId": 2314124,
+      "externalIds": {
+        "ArXiv": "...",
+        "DBLP": "...",
+        "PubMedCentral": "..."
+      },
+      "url": "https://www.semanticscholar.org/paper/649def34f8be52c8b66281af98ae884c09aef38b",
+      "title": "Construction of the Literature Graph in Semantic Scholar",
+      "abstract": "We describe a deployed scalable system for organizing published scientific literature into a heterogeneous graph to facilitate algorithmic manipulation and discovery.",
+      "venue": "International Conference on Software Engineering",
+      "publicationVenue": {
+        "id": "a36dc29e-4ea1-4567-b0fe-1c06daf8bee8",
+        "name": "International Conference on Software Engineering",
+        "type": "conference",
+        "alternate_names": [
+          "IEEE Int Conf Semicond Electron",
+          "IEEE International Conference on Semiconductor Electronics",
+          "ICSE",
+          "Int Conf Softw Eng"
+        ],
+        "url": "http://www.icse-conferences.org/"
+      },
+      "year": 2018,
+      "referenceCount": 321,
+      "citationCount": 987,
+      "influentialCitationCount": 654,
+      "isOpenAccess": true,
+      "openAccessPdf": {
+        "url": "https://www.aclweb.org/anthology/N18-3011.pdf",
+        "status": "HYBRID"
+      },
+      "fieldsOfStudy": [
+        "Computer Science"
+      ],
+      "s2FieldsOfStudy": [
+        {
+          "category": "Computer Science",
+          "source": "external"
+        },
+        {
+          "category": "Computer Science",
+          "source": "s2-fos-model"
+        },
+        {
+          "category": "Mathematics",
+          "source": "s2-fos-model"
+        }
+      ],
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "publicationDate": "2015-01-17",
+      "journal": {
+        "name": "Remote Sensing of Environment",
+        "pages": "255-271",
+        "volume": "176"
+      },
+      "citationStyles": {
+        "bibtex": "@['JournalArticle', 'Conference']{Ammar2018ConstructionOT,\n author = {Waleed Ammar and Dirk Groeneveld and Chandra Bhagavatula and Iz Beltagy and Miles Crawford and Doug Downey and Jason Dunkelberger and Ahmed Elgohary and Sergey Feldman and Vu A. Ha and Rodney Michael Kinney and Sebastian Kohlmeier and Kyle Lo and Tyler C. Murray and Hsu-Han Ooi and Matthew E. Peters and Joanna L. Power and Sam Skjonsberg and Lucy Lu Wang and Christopher Wilhelm and Zheng Yuan and Madeleine van Zuylen and Oren Etzioni},\n booktitle = {NAACL},\n pages = {84-91},\n title = {Construction of the Literature Graph in Semantic Scholar},\n year = {2018}\n}\n"
+      },
+      "authors": [
+        {
+          "authorId": "1741101",
+          "name": "Oren Etzioni"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/sources/fixtures/semantic_paper_search_bulk_no_token.json
+++ b/tests/sources/fixtures/semantic_paper_search_bulk_no_token.json
@@ -1,0 +1,75 @@
+{
+  "total": 15117,
+  "data": [
+    {
+      "paperId": "649def34f8be52c8b66281af98ae884c09aef38b",
+      "corpusId": 2314124,
+      "externalIds": {
+        "ArXiv": "...",
+        "DBLP": "...",
+        "PubMedCentral": "..."
+      },
+      "url": "https://www.semanticscholar.org/paper/649def34f8be52c8b66281af98ae884c09aef38b",
+      "title": "Construction of the Literature Graph in Semantic Scholar",
+      "abstract": "We describe a deployed scalable system for organizing published scientific literature into a heterogeneous graph to facilitate algorithmic manipulation and discovery.",
+      "venue": "International Conference on Software Engineering",
+      "publicationVenue": {
+        "id": "a36dc29e-4ea1-4567-b0fe-1c06daf8bee8",
+        "name": "International Conference on Software Engineering",
+        "type": "conference",
+        "alternate_names": [
+          "IEEE Int Conf Semicond Electron",
+          "IEEE International Conference on Semiconductor Electronics",
+          "ICSE",
+          "Int Conf Softw Eng"
+        ],
+        "url": "http://www.icse-conferences.org/"
+      },
+      "year": 2018,
+      "referenceCount": 321,
+      "citationCount": 987,
+      "influentialCitationCount": 654,
+      "isOpenAccess": true,
+      "openAccessPdf": {
+        "url": "https://www.aclweb.org/anthology/N18-3011.pdf",
+        "status": "HYBRID"
+      },
+      "fieldsOfStudy": [
+        "Computer Science"
+      ],
+      "s2FieldsOfStudy": [
+        {
+          "category": "Computer Science",
+          "source": "external"
+        },
+        {
+          "category": "Computer Science",
+          "source": "s2-fos-model"
+        },
+        {
+          "category": "Mathematics",
+          "source": "s2-fos-model"
+        }
+      ],
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "publicationDate": "2015-01-17",
+      "journal": {
+        "name": "Remote Sensing of Environment",
+        "pages": "255-271",
+        "volume": "176"
+      },
+      "citationStyles": {
+        "bibtex": "@['JournalArticle', 'Conference']{Ammar2018ConstructionOT,\n author = {Waleed Ammar and Dirk Groeneveld and Chandra Bhagavatula and Iz Beltagy and Miles Crawford and Doug Downey and Jason Dunkelberger and Ahmed Elgohary and Sergey Feldman and Vu A. Ha and Rodney Michael Kinney and Sebastian Kohlmeier and Kyle Lo and Tyler C. Murray and Hsu-Han Ooi and Matthew E. Peters and Joanna L. Power and Sam Skjonsberg and Lucy Lu Wang and Christopher Wilhelm and Zheng Yuan and Madeleine van Zuylen and Oren Etzioni},\n booktitle = {NAACL},\n pages = {84-91},\n title = {Construction of the Literature Graph in Semantic Scholar},\n year = {2018}\n}\n"
+      },
+      "authors": [
+        {
+          "authorId": "1741101",
+          "name": "Oren Etzioni"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/sources/test_semantic_scholar.py
+++ b/tests/sources/test_semantic_scholar.py
@@ -1,0 +1,22 @@
+import json
+import re
+from pathlib import Path
+
+import httpx
+import pytest
+
+from peneira.sources.semantic_scholar import BASE_URL, search_semantic_scholar
+
+
+@pytest.mark.respx(base_url="https://api.semanticscholar.org")
+async def test_fetch_articles_from_semantic_scholar(respx_mock):
+    payload = json.loads(
+        Path("tests/sources/fixtures/semantic_paper_search_bulk.json").read_text()
+    )
+    url = re.compile(rf"{BASE_URL}paper/search/bulk*")
+    respx_mock.get(url).mock(return_value=httpx.Response(200, json=payload))
+    query = "syndromic surveilance & machine learning"
+
+    results_bundle = await search_semantic_scholar(query)
+
+    assert len(results_bundle.results) == 1

--- a/tests/sources/test_semantic_scholar.py
+++ b/tests/sources/test_semantic_scholar.py
@@ -5,36 +5,49 @@ from pathlib import Path
 import httpx
 import pytest
 
-from peneira.sources.semantic_scholar import BASE_URL, search_semantic_scholar
+from peneira.sources.semantic_scholar import BASE_URL, SemanticScholar
 
 
 @pytest.mark.respx(base_url="https://api.semanticscholar.org")
 async def test_fetch_articles_from_semantic_scholar(respx_mock):
     payload = json.loads(
-        Path("tests/sources/fixtures/semantic_paper_search_bulk.json").read_text()
+        Path(
+            "tests/sources/fixtures/semantic_paper_search_bulk_no_token.json"
+        ).read_text()
     )
     url = re.compile(rf"{BASE_URL}paper/search/bulk*")
     respx_mock.get(url).mock(return_value=httpx.Response(200, json=payload))
     query = "syndromic surveilance & machine learning"
 
-    results_bundle = await search_semantic_scholar(query)
+    semantic_scholar = SemanticScholar(query=query)
+    results_bundle = await semantic_scholar.search()
 
     assert len(results_bundle.results) == 1
-    assert results_bundle._token == "SDKJFHSDKFHWIEFSFSGHEIURYC"
+    assert semantic_scholar._token is None
 
 
 @pytest.mark.respx(base_url="https://api.semanticscholar.org")
 async def test_fetch_articles_receiving_a_token(respx_mock):
-    payload = json.loads(
+    payload_with_token = json.loads(
         Path("tests/sources/fixtures/semantic_paper_search_bulk.json").read_text()
     )
+    payload_without_token = json.loads(
+        Path(
+            "tests/sources/fixtures/semantic_paper_search_bulk_no_token.json"
+        ).read_text()
+    )
     url = re.compile(rf"{BASE_URL}paper/search/bulk*")
-    respx_mock.get(url).mock(return_value=httpx.Response(200, json=payload))
+    route = respx_mock.get(url)
+    route.side_effect = [
+        httpx.Response(200, json=payload_with_token),
+        httpx.Response(200, json=payload_without_token),
+    ]
+
     query = "syndromic surveilance & machine learning"
 
-    results_bundle = await search_semantic_scholar(
-        query, token="SDKJFHSDKFHWIEFSFSGHEIURYC"
-    )
+    semantic_scholar = SemanticScholar(query=query)
+    results_bundle = await semantic_scholar.search()
 
-    assert len(results_bundle.results) == 1
-    assert results_bundle._token == "SDKJFHSDKFHWIEFSFSGHEIURYC"
+    assert route.call_count == 2
+    assert len(results_bundle.results) == 2
+    assert semantic_scholar._token is None

--- a/tests/sources/test_semantic_scholar.py
+++ b/tests/sources/test_semantic_scholar.py
@@ -20,3 +20,21 @@ async def test_fetch_articles_from_semantic_scholar(respx_mock):
     results_bundle = await search_semantic_scholar(query)
 
     assert len(results_bundle.results) == 1
+    assert results_bundle._token == "SDKJFHSDKFHWIEFSFSGHEIURYC"
+
+
+@pytest.mark.respx(base_url="https://api.semanticscholar.org")
+async def test_fetch_articles_receiving_a_token(respx_mock):
+    payload = json.loads(
+        Path("tests/sources/fixtures/semantic_paper_search_bulk.json").read_text()
+    )
+    url = re.compile(rf"{BASE_URL}paper/search/bulk*")
+    respx_mock.get(url).mock(return_value=httpx.Response(200, json=payload))
+    query = "syndromic surveilance & machine learning"
+
+    results_bundle = await search_semantic_scholar(
+        query, token="SDKJFHSDKFHWIEFSFSGHEIURYC"
+    )
+
+    assert len(results_bundle.results) == 1
+    assert results_bundle._token == "SDKJFHSDKFHWIEFSFSGHEIURYC"


### PR DESCRIPTION
Closes #8.

Add Semantic Scholar as a source.

**Usage**: add `-s` or `--source` before the name of the wanted source. You will be asked to prompt the query for each one.

**Example**:

```
peneira -s semantic_scholar -s open_alex

Please enter the search string for semantic_scholar: syndromic surveillance & machine learning                                                                    
Fetching articles for SEMANTIC_SCHOLAR...
Please enter the search string for open_alex: syndromic surveillance AND machine learning
Fetching articles for OPEN_ALEX... 4447 papers distributed in 23 pages.
Executing the search...
Done.
```

When there are more sources, they will be better shaped. I'm trying to avoid the temptation of refactoring prematurely. :)