### PR TITLE
Add CORE as a new source

### DIFF
--- a/peneira/sources/core.py
+++ b/peneira/sources/core.py
@@ -1,0 +1,29 @@
+import httpx
+from aiolimiter import AsyncLimiter
+from datetime import datetime
+from peneira.sources import ResultBundle
+
+
+BASE_URL = "https://api.core.ac.uk/v3/search"
+SOURCE = "CORE"
+# allows 1,000 tokens per day, maximum 10 per minute for unregistered users
+rate_limiter = AsyncLimiter(10)
+# TODO add support to registered users
+
+
+async def fetch_papers(query, limit=10, offset=0):
+    params = {"q": query, "limit": limit, "offset": offset}
+    async with rate_limiter:  # wait for a slot to be available
+        async with httpx.AsyncClient() as client:
+            response = await client.get(BASE_URL, params=params)
+            results = response.json().get("data", [])
+            return ResultBundle(url=str(response.url), source=SOURCE, results=results)
+
+
+async def establish_number_of_pages(query, limit=10):
+    params = {"q": query, "limit": limit}
+    async with httpx.AsyncClient() as client:
+        response = await client.get(BASE_URL, params=params)
+        total_hits = response.json().get("totalHits", 0)
+        pages = total_hits / limit
+        return int(pages) if pages.is_integer() else int(pages) + 1, total_hits

--- a/tests/sources/test_core.py
+++ b/tests/sources/test_core.py
@@ -1,0 +1,58 @@
+import pytest
+import httpx
+from peneira.sources.core import fetch_papers, establish_number_of_pages
+from peneira.sources import ResultBundle
+
+
+@pytest.mark.asyncio
+async def test_fetch_papers_with_rate_limiting():
+    query = "machine learning"
+    limit = 10
+    offset = 0
+
+    result_bundle = await fetch_papers(query, limit, offset)
+
+    assert isinstance(result_bundle, ResultBundle)
+    assert result_bundle.source == "CORE"
+    assert len(result_bundle.results) <= limit
+    assert all("title" in result for result in result_bundle.results)
+
+
+@pytest.mark.asyncio
+async def test_establish_number_of_pages():
+    query = "machine learning"
+    limit = 10
+
+    pages, total_hits = await establish_number_of_pages(query, limit)
+
+    assert isinstance(pages, int)
+    assert isinstance(total_hits, int)
+    assert pages > 0
+    assert total_hits > 0
+
+
+@pytest.mark.asyncio
+async def test_search_syntax_parsing():
+    query = "title:(machine learning)"
+    limit = 10
+    offset = 0
+
+    result_bundle = await fetch_papers(query, limit, offset)
+
+    assert all("machine learning" in result['title'].lower() for result in result_bundle.results)
+
+
+@pytest.mark.asyncio
+async def test_correct_mapping_to_result_bundle():
+    query = "data science"
+    limit = 5
+    offset = 0
+
+    result_bundle = await fetch_papers(query, limit, offset)
+
+    assert isinstance(result_bundle, ResultBundle)
+    assert result_bundle.source == "CORE"
+    assert 'url' in result_bundle.__dict__
+    assert 'results' in result_bundle.__dict__
+    assert len(result_bundle.results) == limit
+    assert all(isinstance(result, dict) for result in result_bundle.results)


### PR DESCRIPTION
Closes to #11

Integrates CORE as a new source for fetching academic papers, including rate limiting and search syntax parsing.

- **CORE API Integration**: Adds `peneira/sources/core.py` to handle integration with the CORE API, utilizing `httpx.AsyncClient` for asynchronous HTTP requests and `aiolimiter` for rate limiting according to CORE's specifications.
- **Fetching and Pagination**: Implements `fetch_papers` to retrieve papers based on a query, limit, and offset, and `establish_number_of_pages` to calculate the number of pages of results available.
- **Unit Testing**: Introduces `tests/sources/test_core.py` to ensure the functionality of fetching papers, establishing the number of pages, parsing search syntax, and mapping results to the `ResultBundle` structure works as expected.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/anapaulagomes/peneira/issues/11?shareId=a1290dda-7e71-4601-a975-c032132af9de).