### PR TITLE
Add publishing workflow with version selection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version type to bump: major, minor, patch'
+        required: true
+        default: 'patch'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.3'
+        cache: 'poetry'
+    - name: Install Poetry
+      run: |
+        pip install --upgrade pip
+        pip install poetry==1.8.2
+    - name: Bump version and publish to PyPI
+      env:
+        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}
+      run: |
+        poetry config pypi-token.pypi $POETRY_PYPI_TOKEN_PYPI
+        poetry version ${{ github.event.inputs.version }}
+        poetry build
+        poetry publish
+    - name: Commit new version
+      run: |
+        git config --global user.name 'github-actions'
+        git config --global user.email 'github-actions@github.com'
+        git commit -am "Bump version to ${{ github.event.inputs.version }}"
+        git push


### PR DESCRIPTION
Adds a new Github Action workflow for publishing packages to PyPi with Poetry, including version bumping and publishing steps.

- **Workflow Configuration**: Introduces a `publish.yml` workflow file in the `.github/workflows/` directory, designed to be manually triggered with an option to specify the version bump type (`major`, `minor`, `patch`).
- **Python and Poetry Setup**: Sets up Python and installs a specific version of Poetry, ensuring the environment is prepared for package management and publishing.
- **Version Bumping and Publishing**: Utilizes Poetry to configure the PyPi token, bump the package version according to the input, build the package, and publish it to PyPi.
- **Version Committing**: Automatically commits the new version to the repository using a generic GitHub Actions user, maintaining version history directly within the project.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/anapaulagomes/peneira?shareId=122a5c56-62a6-4d22-a73d-c4fce1662c47).